### PR TITLE
Add write support and "userpass" authentication

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject counsyl/vault-clj "0.3.0-SNAPSHOT"
+(defproject counsyl/vault-clj "0.3.1-SNAPSHOT"
   :description "Clojure client for the Vault secret management system."
   :url "https://github.com/counsyl/vault-clj"
   :license {:name "Apache License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject counsyl/vault-clj "0.3.1-SNAPSHOT"
+(defproject counsyl/vault-clj "0.3.0-SNAPSHOT"
   :description "Clojure client for the Vault secret management system."
   :url "https://github.com/counsyl/vault-clj"
   :license {:name "Apache License"

--- a/src/vault/client.clj
+++ b/src/vault/client.clj
@@ -25,9 +25,10 @@
     [client path]
     "List the secrets located under a path.")
 
-  (write-secret
+  (write-secret!
     [client path data]
-    "Writes secret(s) to a specific path. data should be a map.")
+    "Writes secret(s) to a specific path. data should be a map.
+    Returns a boolean indicating whether the write was successful.")
 
   (read-secret
     [client path]
@@ -125,7 +126,7 @@
       (log/infof "List %s (%d results)" path (count data))
       data))
 
-  (write-secret
+  (write-secret!
     [this path data]
     (check-path! path)
     (check-auth! token)

--- a/src/vault/client.clj
+++ b/src/vault/client.clj
@@ -18,11 +18,16 @@
     credentials. Possible arguments:
 
     - :token \"...\"
+    - :userpass {:username \"user\", :password \"hunter2\"}
     - :app-id {:app \"lambda_ci\", :user \"...\"}")
 
   (list-secrets
     [client path]
     "List the secrets located under a path.")
+
+  (write-secret
+    [client path data]
+    "Writes secret(s) to a specific path. data should be a map.")
 
   (read-secret
     [client path]
@@ -72,6 +77,21 @@
                  app (str/join ", " (get-in response [:body :auth :policies])))
       (reset! token-ref client-token))))
 
+(defn- authenticate-userpass!
+  "Updates the token ref by making a request to authenticate with a username
+  and password."
+  [api-url token-ref credentials]
+  (let [{:keys [username password]} credentials
+        response (http/post (str api-url "/v1/auth/userpass/login/" username)
+                   {:form-params {:password password}
+                    :content-type :json
+                    :accept :json
+                    :as :json})]
+    (when-let [client-token (get-in response [:body :auth :client_token])]
+      (log/infof "Successfully authenticated to Vault as %s for policies: %s"
+                 username (str/join ", " (get-in response [:body :auth :policies])))
+      (reset! token-ref client-token))))
+
 
 (defrecord HTTPClient
   [api-url token]
@@ -83,6 +103,7 @@
     (case auth-type
       :token (authenticate-token! token credentials)
       :app-id (authenticate-app! api-url token credentials)
+      :userpass (authenticate-userpass! api-url token credentials)
       ; TODO: support LDAP auth
 
       ; Unknown type
@@ -103,6 +124,19 @@
           data (get-in response [:body :data :keys])]
       (log/infof "List %s (%d results)" path (count data))
       data))
+
+  (write-secret
+    [this path data]
+    (check-path! path)
+    (check-auth! token)
+    (let [response (http/post (str api-url "/v1/" path)
+                     {:headers {"X-Vault-Token" @token}
+                      :form-params data
+                      :content-type :json
+                      :accept :json
+                      :as :json})]
+      (log/infof "Wrote %s" path)
+      (= (:status response) 204)))
 
 
   (read-secret


### PR DESCRIPTION
This PR does what it says on the tin:
- Allows authenticated Vault clients to write data at a given path. HTTP 401 Exceptions will bubble up.
- Allows authentication using the [userpass](https://www.vaultproject.io/docs/auth/userpass.html) backend.
